### PR TITLE
Limit estate manager role

### DIFF
--- a/contracts/land/HighriseLand.sol
+++ b/contracts/land/HighriseLand.sol
@@ -69,7 +69,6 @@ contract HighriseLand is
         _openseaProxyRegistry = ProxyRegistry(openseaProxyRegistry);
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
-        _grantRole(ESTATE_MANAGER_ROLE, msg.sender);
         _grantRole(OWNER_ROLE, msg.sender);
         _setDefaultRoyalty(msg.sender, 500);
     }
@@ -152,6 +151,11 @@ contract HighriseLand is
         require(
             role != OWNER_ROLE || getRoleMemberCount(OWNER_ROLE) == 0,
             "There can be only one owner"
+        );
+        require(
+            role != ESTATE_MANAGER_ROLE ||
+                getRoleMemberCount(ESTATE_MANAGER_ROLE) == 0,
+            "Only estate contract can have ESTATE_MANAGER_ROLE"
         );
         _grantRole(role, account);
     }

--- a/contracts/land/HighriseLandAlt.sol
+++ b/contracts/land/HighriseLandAlt.sol
@@ -76,7 +76,6 @@ contract HighriseLandAlt is
         _openseaProxyRegistry = ProxyRegistry(openseaProxyRegistry);
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
-        _grantRole(ESTATE_MANAGER_ROLE, msg.sender);
         _grantRole(OWNER_ROLE, msg.sender);
         _setDefaultRoyalty(msg.sender, 500);
     }
@@ -159,6 +158,11 @@ contract HighriseLandAlt is
         require(
             role != OWNER_ROLE || getRoleMemberCount(OWNER_ROLE) == 0,
             "There can be only one owner"
+        );
+        require(
+            role != ESTATE_MANAGER_ROLE ||
+                getRoleMemberCount(ESTATE_MANAGER_ROLE) == 0,
+            "Only estate contract can have ESTATE_MANAGER_ROLE"
         );
         _grantRole(role, account);
     }


### PR DESCRIPTION
* Only one address can have an estate manager role at once. 
* Added tests  
* Removed granting that role to `msg.sender` in initialization