### PR TITLE
Add option to modify default royalty

### DIFF
--- a/contracts/land/HighriseEstate.sol
+++ b/contracts/land/HighriseEstate.sol
@@ -312,4 +312,13 @@ contract HighriseEstate is
     }
 
     // ---------------------------------------------------------------------------------
+
+    // ----------------------- ROYALTY -------------------------------------------------
+    function setDefaultRoyalty(address receiver, uint96 feeNumerator)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _setDefaultRoyalty(receiver, feeNumerator);
+    }
+    // ---------------------------------------------------------------------------------
 }

--- a/contracts/land/HighriseLand.sol
+++ b/contracts/land/HighriseLand.sol
@@ -224,4 +224,13 @@ contract HighriseLand is
     }
 
     // ---------------------------------------------------------------------------------
+
+    // ----------------------- ROYALTY -------------------------------------------------
+    function setDefaultRoyalty(address receiver, uint96 feeNumerator)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _setDefaultRoyalty(receiver, feeNumerator);
+    }
+    // ---------------------------------------------------------------------------------
 }

--- a/contracts/land/HighriseLandAlt.sol
+++ b/contracts/land/HighriseLandAlt.sol
@@ -232,6 +232,16 @@ contract HighriseLandAlt is
 
     // ---------------------------------------------------------------------------------
 
+    // ----------------------- ROYALTY -------------------------------------------------
+    function setDefaultRoyalty(address receiver, uint96 feeNumerator)
+        public
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        _setDefaultRoyalty(receiver, feeNumerator);
+    }
+
+    // ---------------------------------------------------------------------------------
+
     // ---------------- ALT FUNCTIONS -------------------------------------------------
     function storeValue(uint256 val) public onlyRole(DEFAULT_ADMIN_ROLE) {
         _val = val;

--- a/tests/land/test_land.py
+++ b/tests/land/test_land.py
@@ -147,3 +147,12 @@ def test_ownership(
     land_contract.revokeRole(land_contract.OWNER_ROLE(), admin, {"from": admin})
     land_contract.grantRole(land_contract.OWNER_ROLE(), alice, {"from": admin})
     assert land_contract.owner() == alice
+
+
+def test_royalty_change(
+    land_contract: ProjectContract, admin: LocalAccount, alice: LocalAccount
+):
+    land_contract.setDefaultRoyalty(alice, 300, {"from": admin}).wait(1)
+    royalty_info = land_contract.royaltyInfo(1, 100)
+    assert royalty_info[0] == alice  # Royalty is owned to the owner
+    assert royalty_info[1] == 3  # Percentage is set to 5


### PR DESCRIPTION
Would like to include this in contracts so we don't need to do the upgrade because of it.  We already set the default royalty in initialization, but there was no public function to modify it afterwards.
This is standard for royalty for marketplaces that support it. The opensea doesn't use it and the owner sets it in the collection edit page on opensea.