### PR TITLE
Generate estate token id from coordinates

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -5,5 +5,5 @@ LAND_BASE_URI_TEMPLATE = "https://cdn-land-{environment}.joinhighrise.com/metada
 ESTATE_NAME = "Highrise ESTATE"
 ESTATE_SYMBOL = "ESTATE"
 ESTATE_BASE_URI_TEMPLATE = (
-    "https://highrise-estate-{environment}.s3.amazonaws.com/metadata/"
+    "https://cdn-land-{environment}.joinhighrise.com/estates-metadata/"
 )

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -61,18 +61,24 @@ def upgrade(
                 proxy.address,
                 new_implementation_address,
                 encoded_function_call,
-                {"from": account},
+                {"from": account, "gas_limit": 2000000},
             )
         else:
             transaction = proxy_admin_contract.upgrade(
-                proxy.address, new_implementation_address, {"from": account}
+                proxy.address,
+                new_implementation_address,
+                {"from": account, "gas_limit": 2000000},
             )
     else:
         if initializer:
             encoded_function_call = encode_function_data(initializer, *args)
             transaction = proxy.upgradeToAndCall(
-                new_implementation_address, encoded_function_call, {"from": account}
+                new_implementation_address,
+                encoded_function_call,
+                {"from": account, "gas_limit": 2000000},
             )
         else:
-            transaction = proxy.upgradeTo(new_implementation_address, {"from": account})
+            transaction = proxy.upgradeTo(
+                new_implementation_address, {"from": account, "gas_limit": 2000000}
+            )
     return transaction


### PR DESCRIPTION
* Estate token id is now the same as top-left land token id so it is easier to deduce the position of the estate on map in the backend code
* Custom mint event is emitted